### PR TITLE
Add physics manager class

### DIFF
--- a/le3/include/le3_engine_systems.h
+++ b/le3/include/le3_engine_systems.h
@@ -11,6 +11,7 @@
 #include "le3_scene_manager.h"
 #include "le3_editor_manager.h"
 #include "le3_event_manager.h"
+#include "le3_physics_manager.h"
 
 namespace le3 {
     // Singleton for various (global) engine systems, which are not specific to any scene
@@ -54,6 +55,7 @@ namespace le3 {
         inline LE3SceneManager& getSceneManager() { return g_sceneManager; }
         inline LE3EditorManager& getEditorManager() { return g_editorManager; }
         inline LE3EventManager& getEventManager() { return g_eventManager; }
+        inline LE3PhysicsManager& getPhysicsManager() { return g_physicsManager; }
         inline bool isHeadless() { return g_headlessEngine; }
 
         inline bool isRequestingReset() { return g_requestReset; }
@@ -71,6 +73,7 @@ namespace le3 {
         LE3SceneManager g_sceneManager;
         LE3EditorManager g_editorManager;
         LE3EventManager g_eventManager;
+        LE3PhysicsManager g_physicsManager;
 
         bool g_headlessEngine;
         bool g_requestReset = false;

--- a/le3/include/le3_physics.h
+++ b/le3/include/le3_physics.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace le3 {
+    
+}
+

--- a/le3/include/le3_physics_manager.h
+++ b/le3/include/le3_physics_manager.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace le3 {
+    class LE3PhysicsManager {
+    public:
+        void reset();
+
+
+    private:
+    };
+}
+

--- a/le3/src/le3_engine_systems.cpp
+++ b/le3/src/le3_engine_systems.cpp
@@ -15,6 +15,7 @@ void LE3EngineSystems::reset() {
     g_sceneManager.reset();
     g_editorManager.reset();
     g_eventManager.reset();
+    g_physicsManager.reset();
     
     // preload(g_headlessEngine);
     // init();

--- a/le3/src/le3_physics.cpp
+++ b/le3/src/le3_physics.cpp
@@ -1,0 +1,2 @@
+#include "le3_physics.h"
+using namespace le3;

--- a/le3/src/le3_physics_manager.cpp
+++ b/le3/src/le3_physics_manager.cpp
@@ -1,0 +1,5 @@
+#include "le3_physics_manager.h"
+using namespace le3;
+
+void LE3PhysicsManager::reset() {
+}


### PR DESCRIPTION
The previous CMake file breaks without the physics manager cpp files.